### PR TITLE
Change default isPublic bool

### DIFF
--- a/src/components/app-upload.js
+++ b/src/components/app-upload.js
@@ -3,14 +3,12 @@ import { connect } from 'react-redux'
 import { Form, Checkbox, Button, Modal, Icon } from 'semantic-ui-react'
 import { uploadFile, fetchFiles } from '../actions/index'
 
-// import './css/appupload.css'
-
 class AppUpload extends Component {
   constructor(props) {
     super(props)
     this.state = {
       fileName: '',
-      isPublic: false,
+      isPublic: true,
       fileData: '',
       showModal: false
     }


### PR DESCRIPTION
I think this should be isPublic by default as when uploading a media on noticeboard it needed to be a public file otherwise more queries will arise otherwise.