### PR TITLE
Fix: Breadcrumbs resolve

### DIFF
--- a/src/components/admin.js
+++ b/src/components/admin.js
@@ -4,7 +4,7 @@ import css from './css/approveRequest.css'
 import ErrorBoundary from './error-boundary'
 
 class Admin extends Component {
-  render () {
+  render() {
     return (
       <ErrorBoundary>
         <Container styleName='css.main-container'>
@@ -14,17 +14,13 @@ class Admin extends Component {
             fluid
             color='red'
             header='Approve Data Requests'
-            onClick={() =>
-              this.props.history.push('/file-manager/admin/approve')
-            }
+            onClick={() => this.props.history.push(`${BASE_URL}/admin/approve`)}
           />
           <Card
             fluid
             color='red'
             header='Create new filemanager instance'
-            onClick={() =>
-              this.props.history.push('/file-manager/admin/create')
-            }
+            onClick={() => this.props.history.push(`${BASE_URL}/admin/create`)}
           />
         </Container>
       </ErrorBoundary>

--- a/src/components/bar.js
+++ b/src/components/bar.js
@@ -22,12 +22,12 @@ import {
   bulkDeleteFolders
 } from '../actions/folderActions'
 import { deleteFile, editFile, bulkDeleteFiles } from '../actions/fileActions'
-import { ITEM_TYPE } from '../constants'
+import { BASE_URL, ITEM_TYPE } from '../constants'
 import ItemDetailsModal from './item-detail-modal'
 import { handleDownload } from '../helpers/helperfunctions'
 
 class Bar extends Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = {
       isDelete: false,
@@ -128,7 +128,7 @@ class Bar extends Component {
       isDelete: false
     })
   }
-  render () {
+  render() {
     const {
       tabular,
       activeItems,
@@ -153,7 +153,7 @@ class Bar extends Component {
                 icon
                 labelPosition='left'
                 color='blue'
-                to={`/file-manager/${this.props.match.params.filemanager}/`}
+                to={`${BASE_URL}/${this.props.match.params.filemanager}/`}
               >
                 <Icon name='home' />
                 Home
@@ -196,7 +196,7 @@ class Bar extends Component {
               icon
               labelPosition='left'
               color='grey'
-              to={`/file-manager/${this.props.match.params.filemanager}/shared_with_me/`}
+              to={`${BASE_URL}/${this.props.match.params.filemanager}/shared_with_me/`}
             >
               <Icon name='share' />
               Shared With Me
@@ -208,7 +208,7 @@ class Bar extends Component {
               icon
               labelPosition='left'
               color='grey'
-              to={`/file-manager/${this.props.match.params.filemanager}/all_starred_items/`}
+              to={`${BASE_URL}/${this.props.match.params.filemanager}/all_starred_items/`}
             >
               <Icon name='star' />
               Starred

--- a/src/components/filemanager-card.js
+++ b/src/components/filemanager-card.js
@@ -28,7 +28,7 @@ class Filemanagercard extends Component {
       <Card
         styleName="filemanager-card"
         onDoubleClick={() => {
-          const url = `/file-manager/${folder.filemanager.filemanagerUrlPath}/`
+          const url = `${BASE_URL}/${folder.filemanager.filemanagerUrlPath}/`
           this.props.history.push(url)
         }}
         onClick={() => setActiveFolder(folder)}

--- a/src/components/folder-card.js
+++ b/src/components/folder-card.js
@@ -8,7 +8,7 @@ import grid from './css/grid-view.css'
 import { withRouter } from 'react-router-dom'
 import { setActiveItems } from '../actions/itemActions'
 import { deleteFolder } from '../actions/folderActions'
-import { ITEM_TYPE } from '../constants'
+import { BASE_URL, ITEM_TYPE } from '../constants'
 
 class FolderCard extends Component {
   constructor(props) {
@@ -50,8 +50,8 @@ class FolderCard extends Component {
       ? this.props.match.type_shared
       : 'folder'
     const url = viewingSharedItems
-      ? `/file-manager/${this.props.match.params.filemanager}/${uuid}/${type_shared}/${folder.id}/folder/`
-      : `/file-manager/${this.props.match.params.filemanager}/${folder.id}/`
+      ? `${BASE_URL}/${this.props.match.params.filemanager}/${uuid}/${type_shared}/${folder.id}/folder/`
+      : `${BASE_URL}/${this.props.match.params.filemanager}/${folder.id}/`
     this.props.history.push(url)
   }
 

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -54,30 +54,34 @@ class Progress extends Component {
               <Breadcrumb.Section
                 onClick={() => {
                   this.props.history.push(
-                    viewingSharedItems
-                      ? `/file-manager/${this.props.match.params.filemanager}/shared_with_me/`
-                      : `/file-manager/${this.props.match.params.filemanager}/`
+                    `/file-manager/${this.props.match.params.filemanager}/`
                   )
                 }}
                 link
               >
-                {viewingSharedItems
-                  ? folder.filemanager
-                  : folder.filemanagername}
+                {folder.filemanagername}
               </Breadcrumb.Section>
-              {viewingSharedItems ? <React.Fragment>
-                <Breadcrumb.Divider icon='right chevron' />
-              </React.Fragment> : ''}
-              {viewingSharedItems ? <Breadcrumb.Section
-                onClick={() => {
-                  this.props.history.push(
-                    `/file-manager/shared_with_me/`
-                  )
-                }}
-                link
-              >
-                shared_with_me
-              </Breadcrumb.Section> : '' }
+              {viewingSharedItems ? (
+                <React.Fragment>
+                  <Breadcrumb.Divider icon='right chevron' />
+                </React.Fragment>
+              ) : (
+                ''
+              )}
+              {viewingSharedItems ? (
+                <Breadcrumb.Section
+                  onClick={() => {
+                    this.props.history.push(
+                      `/file-manager/${this.props.match.params.filemanager}/shared_with_me`
+                    )
+                  }}
+                  link
+                >
+                  shared_with_me
+                </Breadcrumb.Section>
+              ) : (
+                ''
+              )}
               {arr && arr.length
                 ? arr.map((data, index) => (
                     <React.Fragment>

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -50,15 +50,20 @@ class Progress extends Component {
               <React.Fragment>
                 <Breadcrumb.Divider icon='right chevron' />
               </React.Fragment>
+
               <Breadcrumb.Section
                 onClick={() => {
                   this.props.history.push(
-                    `/file-manager/${this.props.match.params.filemanager}/`
+                    viewingSharedItems
+                      ? `/file-manager/${this.props.match.params.filemanager}/shared_with_me/`
+                      : `/file-manager/${this.props.match.params.filemanager}/`
                   )
                 }}
                 link
               >
-                {folder.filemanagername}
+                {viewingSharedItems
+                  ? folder.filemanager
+                  : folder.filemanagername}
               </Breadcrumb.Section>
               {viewingSharedItems ? <React.Fragment>
                 <Breadcrumb.Divider icon='right chevron' />

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -3,14 +3,14 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { Breadcrumb } from 'semantic-ui-react'
 import { getParentFolders } from '../actions/folderActions'
-
+import { BASE_URL } from '../constants'
 import index from './css/index.css'
 
 class Progress extends Component {
   handleClick = data => {
     const { viewingSharedItems } = this.props
     if (!viewingSharedItems && data.id) {
-      const url = `/file-manager/${this.props.match.params.filemanager}/${data.id}/`
+      const url = `${BASE_URL}/${this.props.match.params.filemanager}/${data.id}/`
       this.props.history.push(url)
     }
   }
@@ -41,7 +41,7 @@ class Progress extends Component {
             <>
               <Breadcrumb.Section
                 onClick={() => {
-                  this.props.history.push(`/file-manager/`)
+                  this.props.history.push(`${BASE_URL}/`)
                 }}
                 link
               >
@@ -54,7 +54,7 @@ class Progress extends Component {
               <Breadcrumb.Section
                 onClick={() => {
                   this.props.history.push(
-                    `/file-manager/${this.props.match.params.filemanager}/`
+                    `${BASE_URL}/${this.props.match.params.filemanager}/`
                   )
                 }}
                 link
@@ -72,7 +72,7 @@ class Progress extends Component {
                 <Breadcrumb.Section
                   onClick={() => {
                     this.props.history.push(
-                      `/file-manager/${this.props.match.params.filemanager}/shared_with_me`
+                      `${BASE_URL}/${this.props.match.params.filemanager}/shared_with_me`
                     )
                   }}
                   link

--- a/src/components/shareItemModal.js
+++ b/src/components/shareItemModal.js
@@ -19,7 +19,7 @@ import {
 } from 'semantic-ui-react'
 
 import { FileIcon } from 'react-file-icon'
-import { FILE_TYPES } from '../constants'
+import { BASE_URL, FILE_TYPES } from '../constants'
 import { setActiveItems } from '../actions/itemActions'
 import { USER_APIS } from '../urls'
 
@@ -27,7 +27,7 @@ import file from './css/share-item.css'
 import { toast } from 'react-semantic-toasts'
 
 class ShareItemModal extends Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = {
       isLoading: false,
@@ -150,17 +150,22 @@ class ShareItemModal extends Component {
     document.execCommand('copy')
   }
 
-  render () {
+  render() {
     const { activeItems, showModal, close, filemanager } = this.props
     const { isLoading, options, selectedUsersFinally } = this.state
-    console.log(window.location.origin)
     const link =
       activeItems.length == 1
-        ? activeItems[0].type=="folder" ? `${window.location.origin}/file-manager/${filemanager}/${activeItems[0].obj.sharingId}/${activeItems[0].type}/${activeItems[0].obj.id}/${activeItems[0].type}`
-        : activeItems[0].obj.upload.includes(window.location.origin) ? `${activeItems[0].obj.upload}` : `${window.location.origin}${activeItems[0].obj.upload}` : ''
+        ? activeItems[0].type == 'folder'
+          ? `${window.location.origin}${BASE_URL}/${filemanager}/${activeItems[0].obj.sharingId}/${activeItems[0].type}/${activeItems[0].obj.id}/${activeItems[0].type}`
+          : activeItems[0].obj.upload.includes(window.location.origin)
+          ? `${activeItems[0].obj.upload}`
+          : `${window.location.origin}${activeItems[0].obj.upload}`
+        : ''
     return (
       <Modal
-        onClick={(e) => {e.stopPropagation()}}
+        onClick={e => {
+          e.stopPropagation()
+        }}
         size='large'
         open={showModal}
         closeOnEscape={true}

--- a/src/components/tabular-view.js
+++ b/src/components/tabular-view.js
@@ -9,7 +9,7 @@ import PopupView from './popup'
 
 import index from './css/index.css'
 import { getStarredItems, setActiveItems } from '../actions/itemActions'
-import { FILE_TYPES, IMAGE_EXTENSIONS, ITEM_TYPE } from '../constants'
+import { BASE_URL, FILE_TYPES, IMAGE_EXTENSIONS, ITEM_TYPE } from '../constants'
 import { FileIcon } from 'react-file-icon'
 import {
   createContextFromEvent,
@@ -124,8 +124,8 @@ class TabularView extends Component {
       ? this.props.match.type_shared
       : 'folder'
     const url = viewingSharedItems
-      ? `/file-manager/${this.props.match.params.filemanager}/${uuid}/${type_shared}/${folder.id}/folder/`
-      : `/file-manager/${this.props.match.params.filemanager}/${folder.id}/`
+      ? `${BASE_URL}/${this.props.match.params.filemanager}/${uuid}/${type_shared}/${folder.id}/folder/`
+      : `${BASE_URL}/${this.props.match.params.filemanager}/${folder.id}/`
     this.props.history.push(url)
   }
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,5 @@
+const configJson = require('../../config.json')
+
 export const ITEM_TYPE = Object.freeze({
   folder: 'folder',
   file: 'file'
@@ -403,7 +405,7 @@ export const spaceOptions = [
 export const spaceOptionUnits = [
   { key: '1', text: 'GB', value: ONE_GB },
   { key: '2', text: 'MB', value: ONE_MB },
-  { key: '3', text: 'KB', value: ONE_KB },
+  { key: '3', text: 'KB', value: ONE_KB }
 ]
 
 export const roleOptions = [
@@ -440,3 +442,5 @@ export const PERSON_ROLES = Object.freeze({
   MAINTAINER: 'Maintainer',
   GUEST: 'Guest'
 })
+
+export const BASE_URL = configJson.baseUrl


### PR DESCRIPTION
- Resolve Breadcrumbs not showing error in case of viewing  shared items
- store "/file-manager" in a variable so to make it easy to configure base_url